### PR TITLE
Include current RootCertificates state

### DIFF
--- a/rotation/roots.go
+++ b/rotation/roots.go
@@ -131,7 +131,7 @@ func RotateRootCertificates(ctx context.Context, storage nodeenrollment.Storage,
 		Current: nextCurrent,
 		Next:    nextNext,
 	}
-	if currentRoots.GetState() != nil {
+	if currentRoots != nil {
 		ret.State = currentRoots.State
 	}
 

--- a/rotation/roots.go
+++ b/rotation/roots.go
@@ -131,6 +131,9 @@ func RotateRootCertificates(ctx context.Context, storage nodeenrollment.Storage,
 		Current: nextCurrent,
 		Next:    nextNext,
 	}
+	if currentRoots.GetState() != nil {
+		ret.State = currentRoots.State
+	}
 
 	if !opts.WithSkipStorage {
 		if err := ret.Store(ctx, storage, opt...); err != nil {


### PR DESCRIPTION
Include current RootCertificates state when storing new RootCertificates to preserve version
