### PR TITLE
Don't require storage if upstream functions are set

### DIFF
--- a/protocol/listener.go
+++ b/protocol/listener.go
@@ -80,12 +80,19 @@ func NewInterceptingListener(
 		return nil, fmt.Errorf("(%s) configuration is nil", op)
 	case nodeenrollment.IsNil(config.Context):
 		return nil, fmt.Errorf("(%s) context is nil", op)
-	case nodeenrollment.IsNil(config.Storage):
-		return nil, fmt.Errorf("(%s) storage is nil", op)
 	case nodeenrollment.IsNil(config.BaseListener):
 		return nil, fmt.Errorf("(%s) base listener is nil", op)
 	case config.BaseTlsConfiguration == nil:
 		return nil, fmt.Errorf("(%s) base tls configuration is nil", op)
+	}
+
+	// These functions are where we use storage, so if they are being
+	// overridden, allow the provider to perform their own checks. This lets
+	// some function providers not have to instantiate storage if they don't
+	// need it.
+	if nodeenrollment.IsNil(config.Storage) &&
+		(config.FetchCredsFunc == nil || config.GenerateServerCertificatesFunc == nil) {
+		return nil, fmt.Errorf("(%s) storage is nil but not all function options are non-nil", op)
 	}
 
 	l := &InterceptingListener{

--- a/storage/file/file.go
+++ b/storage/file/file.go
@@ -76,7 +76,7 @@ func (ts *Storage) BaseDir() string {
 
 // Cleanup provides a function to clean up after tests
 func (ts *Storage) Cleanup() {
-	if ts.skipCleanup {
+	if ts == nil || ts.skipCleanup {
 		return
 	}
 	os.RemoveAll(ts.baseDir)


### PR DESCRIPTION
If we are passed custom functions, allow storage to be nil. If those
functions are merely proxying, this allows us to avoid creating file
storage that is never actually used.

This also adds a bit of defense in depth to file cleanup.