### PR TITLE
Allow application-defined extra ALPN protos

### DIFF
--- a/options.go
+++ b/options.go
@@ -41,6 +41,7 @@ type Options struct {
 	WithState                *structpb.Struct
 	WithAlpnProtoPrefix      string
 	WithServerName           string
+	WithExtraAlpnProtos      []string
 }
 
 // Option is a function that takes in an options struct and sets values or
@@ -168,6 +169,17 @@ func WithAlpnProtoPrefix(with string) Option {
 func WithServerName(with string) Option {
 	return func(o *Options) error {
 		o.WithServerName = with
+		return nil
+	}
+}
+
+// WithExtraAlpnProtos is used to allow passing additional ALPN protos in via a
+// ClientHello message, e.g. via the Dial function in the protocol package. This
+// can allow users of the library to perform an extra switch on the desired
+// protocol post-authentication.
+func WithExtraAlpnProtos(with []string) Option {
+	return func(o *Options) error {
+		o.WithExtraAlpnProtos = with
 		return nil
 	}
 }

--- a/options_test.go
+++ b/options_test.go
@@ -126,7 +126,7 @@ func Test_GetOpts(t *testing.T) {
 		opts, err = GetOpts(WithAlpnProtoPrefix(AuthenticateNodeNextProtoV1Prefix))
 		require.NoError(err)
 		assert.Equal(AuthenticateNodeNextProtoV1Prefix, opts.WithAlpnProtoPrefix)
-		opts, err = GetOpts(WithAlpnProtoPrefix("foobar"))
+		_, err = GetOpts(WithAlpnProtoPrefix("foobar"))
 		require.Error(err)
 	})
 	t.Run("with-server-name", func(t *testing.T) {
@@ -137,5 +137,14 @@ func Test_GetOpts(t *testing.T) {
 		opts, err = GetOpts(WithServerName("foobar"))
 		require.NoError(err)
 		assert.Equal("foobar", opts.WithServerName)
+	})
+	t.Run("with-extra-alpn-protos", func(t *testing.T) {
+		assert, require := assert.New(t), require.New(t)
+		opts, err := GetOpts()
+		require.NoError(err)
+		assert.Empty(opts.WithExtraAlpnProtos)
+		opts, err = GetOpts(WithExtraAlpnProtos([]string{"foo", "bar"}))
+		require.NoError(err)
+		assert.Equal([]string{"foo", "bar"}, opts.WithExtraAlpnProtos)
 	})
 }

--- a/protocol/conn.go
+++ b/protocol/conn.go
@@ -1,0 +1,26 @@
+package protocol
+
+import "crypto/tls"
+
+// Conn embeds a *tls.Conn and allows us to add extra bits into it
+type Conn struct {
+	*tls.Conn
+	clientNextProtos []string
+}
+
+// ClientNextProtos returns the value of NextProtos originally presented by the
+// client at connection time
+func (c *Conn) ClientNextProtos() []string {
+	switch {
+	case c == nil:
+		return nil
+	case c.clientNextProtos == nil:
+		return nil
+	case len(c.clientNextProtos) == 0:
+		return []string{}
+	default:
+		ret := make([]string, len(c.clientNextProtos))
+		copy(ret, c.clientNextProtos)
+		return ret
+	}
+}

--- a/protocol/dialer.go
+++ b/protocol/dialer.go
@@ -26,7 +26,9 @@ import (
 // Supported options: WithRandomReader, WithWrapper (passed through to
 // LoadNodeCredentials and NodeCredentials.Store),
 // WithNotBeforeClockSkew/WithNotAfterClockSkew (these are used as
-// NotBefore/NotAfter lifetimes for the generated cert used for client side TLS)
+// NotBefore/NotAfter lifetimes for the generated cert used for client side
+// TLS), WithExtraAlpnProtos (passed through to the client side TLS
+// configuration)
 func Dial(
 	ctx context.Context,
 	storage nodeenrollment.Storage,

--- a/protocol/tls.go
+++ b/protocol/tls.go
@@ -22,131 +22,139 @@ import (
 //
 // Supported options: WithWrapper (passed through to LoadRootCertificate),
 // WithRandReader (passed through to ServerConfig and GenerateServerCertificates)
-func (l *InterceptingListener) getTlsConfigForClient(hello *tls.ClientHelloInfo) (*tls.Config, error) {
+func (l *InterceptingListener) getTlsConfigForClient(clientInfo *ClientInfo) func(*tls.ClientHelloInfo) (*tls.Config, error) {
 	const op = "nodeenrollment.protocol.(InterceptingListener).getTlsConfigForClient"
 
-	// If they aren't announcing support, return the base configuration
-	if !nodeenrollment.ContainsKnownAlpnProto(hello.SupportedProtos...) {
-		if l.baseTlsConf == nil {
-			return nil, fmt.Errorf("(%s) no base tls configuration and no library next proto", op)
+	return func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
+		// Copy client next proto information to returned value
+		if len(hello.SupportedProtos) > 0 {
+			clientInfo.NextProtos = make([]string, len(hello.SupportedProtos))
+			copy(clientInfo.NextProtos, hello.SupportedProtos)
 		}
-		if l.baseTlsConf.GetConfigForClient != nil {
-			return l.baseTlsConf.GetConfigForClient(hello)
+
+		// If they aren't announcing support, return the base configuration
+		if !nodeenrollment.ContainsKnownAlpnProto(hello.SupportedProtos...) {
+			if l.baseTlsConf == nil {
+				return nil, fmt.Errorf("(%s) no base tls configuration and no library next proto", op)
+			}
+			if l.baseTlsConf.GetConfigForClient != nil {
+				return l.baseTlsConf.GetConfigForClient(hello)
+			}
+			return l.baseTlsConf, nil
 		}
-		return l.baseTlsConf, nil
-	}
 
-	serverCertsReq := new(types.GenerateServerCertificatesRequest)
-	var protoToReturn string
-	opt := l.options
+		serverCertsReq := new(types.GenerateServerCertificatesRequest)
+		var protoToReturn string
+		opt := l.options
 
-	for _, p := range hello.SupportedProtos {
-		switch {
-		// In either scenario, we will present a carefully curated server
-		// certificate with information the node can use. How that certificate
-		// is generated depends on the path.
-		case strings.HasPrefix(p, nodeenrollment.FetchNodeCredsNextProtoV1Prefix):
-			// Get the full string and pull out just the marshaled proto
-			protoString, err := nodetls.CombineFromNextProtos(nodeenrollment.FetchNodeCredsNextProtoV1Prefix, hello.SupportedProtos)
-			if err != nil {
-				return nil, fmt.Errorf("(%s) error combining fetch node creds next proto value", op)
-			}
-			// Get the raw proto bytes
-			reqBytes, err := base64.RawStdEncoding.DecodeString(protoString)
-			if err != nil {
-				return nil, fmt.Errorf("(%s) error base64-decoding fetch node creds next proto value", op)
-			}
-			// Decode the proto into the request
-			req := new(types.FetchNodeCredentialsRequest)
-			if err := proto.Unmarshal(reqBytes, req); err != nil {
-				return nil, fmt.Errorf("(%s) error unmarshaling common name value: %w", op, err)
-			}
-			// This will return a response either with Authorized false and no
-			// other data or Authorized true and encrypted values
-			fetchResp, err := l.fetchCredsFn(l.ctx, l.storage, req, l.options...)
-			if err != nil {
-				return nil, fmt.Errorf("(%s) error handling fetch creds: %w", op, err)
-			}
-
-			// This is a bit redundant with the fetch function above but we need
-			// a few values
-			var reqInfo types.FetchNodeCredentialsInfo
-			if err := proto.Unmarshal(req.Bundle, &reqInfo); err != nil {
-				return nil, fmt.Errorf("(%s) cannot unmarshal request info: %w", op, err)
-			}
-
+		for _, p := range hello.SupportedProtos {
 			switch {
-			case fetchResp == nil:
-				// In this case we're not authorized, use the standard common
-				// name and we'll detect this on the fetch side. If we try to
-				// marshal the empty value we end up with a zero length message,
-				// a zero-length base-64 message, and hit an error later if we
-				// don't remember this when decoding. So just use a canary.
-				serverCertsReq.CommonName = nodeenrollment.CommonDnsName
+			// In either scenario, we will present a carefully curated server
+			// certificate with information the node can use. How that certificate
+			// is generated depends on the path.
+			case strings.HasPrefix(p, nodeenrollment.FetchNodeCredsNextProtoV1Prefix):
+				// Get the full string and pull out just the marshaled proto
+				protoString, err := nodetls.CombineFromNextProtos(nodeenrollment.FetchNodeCredsNextProtoV1Prefix, hello.SupportedProtos)
+				if err != nil {
+					return nil, fmt.Errorf("(%s) error combining fetch node creds next proto value", op)
+				}
+				// Get the raw proto bytes
+				reqBytes, err := base64.RawStdEncoding.DecodeString(protoString)
+				if err != nil {
+					return nil, fmt.Errorf("(%s) error base64-decoding fetch node creds next proto value", op)
+				}
+				// Decode the proto into the request
+				req := new(types.FetchNodeCredentialsRequest)
+				if err := proto.Unmarshal(reqBytes, req); err != nil {
+					return nil, fmt.Errorf("(%s) error unmarshaling common name value: %w", op, err)
+				}
+				// This will return a response either with Authorized false and no
+				// other data or Authorized true and encrypted values
+				fetchResp, err := l.fetchCredsFn(l.ctx, l.storage, req, l.options...)
+				if err != nil {
+					return nil, fmt.Errorf("(%s) error handling fetch creds: %w", op, err)
+				}
+
+				// This is a bit redundant with the fetch function above but we need
+				// a few values
+				var reqInfo types.FetchNodeCredentialsInfo
+				if err := proto.Unmarshal(req.Bundle, &reqInfo); err != nil {
+					return nil, fmt.Errorf("(%s) cannot unmarshal request info: %w", op, err)
+				}
+
+				switch {
+				case fetchResp == nil:
+					// In this case we're not authorized, use the standard common
+					// name and we'll detect this on the fetch side. If we try to
+					// marshal the empty value we end up with a zero length message,
+					// a zero-length base-64 message, and hit an error later if we
+					// don't remember this when decoding. So just use a canary.
+					serverCertsReq.CommonName = nodeenrollment.CommonDnsName
+
+				default:
+					fetchRespBytes, err := proto.Marshal(fetchResp)
+					if err != nil {
+						return nil, fmt.Errorf("(%s) error marshaling fetch response: %w", op, err)
+					}
+					// Have the response put into the common name
+					serverCertsReq.CommonName = base64.RawStdEncoding.EncodeToString(fetchRespBytes)
+				}
+
+				// We are returning either unauthorized or encrypted creds so we
+				// don't want to validate the node's credentials -- it doesn't have
+				// them yet!
+				serverCertsReq.SkipVerification = true
+				serverCertsReq.Nonce = reqInfo.Nonce
+				serverCertsReq.CertificatePublicKeyPkix = reqInfo.CertificatePublicKeyPkix
+				protoToReturn = p
+				// This is a hint to the standard TLS verification function to just allow it
+				opt = append(opt, nodeenrollment.WithAlpnProtoPrefix(nodeenrollment.FetchNodeCredsNextProtoV1Prefix))
+
+			case strings.HasPrefix(p, nodeenrollment.AuthenticateNodeNextProtoV1Prefix):
+				// Get the full string and pull out just the marshaled proto
+				protoString, err := nodetls.CombineFromNextProtos(nodeenrollment.AuthenticateNodeNextProtoV1Prefix, hello.SupportedProtos)
+				if err != nil {
+					return nil, fmt.Errorf("(%s) error combining auth node next proto value", op)
+				}
+				// Get the raw proto bytes
+				reqBytes, err := base64.RawStdEncoding.DecodeString(protoString)
+				if err != nil {
+					return nil, fmt.Errorf("(%s) error base64-decoding auth node next proto value", op)
+				}
+				// Decode the certs request
+				if err := proto.Unmarshal(reqBytes, serverCertsReq); err != nil {
+					return nil, fmt.Errorf("(%s) error unmarshaling common name value: %w", op, err)
+				}
+				protoToReturn = p
 
 			default:
-				fetchRespBytes, err := proto.Marshal(fetchResp)
-				if err != nil {
-					return nil, fmt.Errorf("(%s) error marshaling fetch response: %w", op, err)
-				}
-				// Have the response put into the common name
-				serverCertsReq.CommonName = base64.RawStdEncoding.EncodeToString(fetchRespBytes)
+				continue
 			}
 
-			// We are returning either unauthorized or encrypted creds so we
-			// don't want to validate the node's credentials -- it doesn't have
-			// them yet!
-			serverCertsReq.SkipVerification = true
-			serverCertsReq.Nonce = reqInfo.Nonce
-			serverCertsReq.CertificatePublicKeyPkix = reqInfo.CertificatePublicKeyPkix
-			protoToReturn = p
-			// This is a hint to the standard TLS verification function to just allow it
-			opt = append(opt, nodeenrollment.WithAlpnProtoPrefix(nodeenrollment.FetchNodeCredsNextProtoV1Prefix))
-
-		case strings.HasPrefix(p, nodeenrollment.AuthenticateNodeNextProtoV1Prefix):
-			// Get the full string and pull out just the marshaled proto
-			protoString, err := nodetls.CombineFromNextProtos(nodeenrollment.AuthenticateNodeNextProtoV1Prefix, hello.SupportedProtos)
-			if err != nil {
-				return nil, fmt.Errorf("(%s) error combining auth node next proto value", op)
-			}
-			// Get the raw proto bytes
-			reqBytes, err := base64.RawStdEncoding.DecodeString(protoString)
-			if err != nil {
-				return nil, fmt.Errorf("(%s) error base64-decoding auth node next proto value", op)
-			}
-			// Decode the certs request
-			if err := proto.Unmarshal(reqBytes, serverCertsReq); err != nil {
-				return nil, fmt.Errorf("(%s) error unmarshaling common name value: %w", op, err)
-			}
-			protoToReturn = p
-
-		default:
-			continue
+			// If we're here we found one of our known protos so break out of
+			// the for loop and finish
+			break
 		}
 
-		// If we're here we found one of our known protos so break out of
-		// the for loop and finish
-		break
-	}
+		// Generate a server-side certificate
+		certResp, err := l.generateServerCertificatesFn(l.ctx, l.storage, serverCertsReq, opt...)
+		if err != nil {
+			return nil, fmt.Errorf("(%s) error generating server-side certificate: %w", op, err)
+		}
+		if certResp == nil {
+			return nil, fmt.Errorf("(%s) nil response when generating server-side certificate", op)
+		}
 
-	// Generate a server-side certificate
-	certResp, err := l.generateServerCertificatesFn(l.ctx, l.storage, serverCertsReq, opt...)
-	if err != nil {
-		return nil, fmt.Errorf("(%s) error generating server-side certificate: %w", op, err)
-	}
-	if certResp == nil {
-		return nil, fmt.Errorf("(%s) nil response when generating server-side certificate", op)
-	}
+		// Ensure that the key we just verified from the signature is the one
+		// presented by the client when we handshake
+		opt = append(opt, nodeenrollment.WithExpectedPublicKey(serverCertsReq.CertificatePublicKeyPkix))
 
-	// Ensure that the key we just verified from the signature is the one
-	// presented by the client when we handshake
-	opt = append(opt, nodeenrollment.WithExpectedPublicKey(serverCertsReq.CertificatePublicKeyPkix))
+		tlsConf, err := nodetls.ServerConfig(l.ctx, certResp, opt...)
+		if err != nil {
+			return nil, fmt.Errorf("(%s) error generating root tls config: %w", op, err)
+		}
 
-	tlsConf, err := nodetls.ServerConfig(l.ctx, certResp, opt...)
-	if err != nil {
-		return nil, fmt.Errorf("(%s) error generating root tls config: %w", op, err)
+		tlsConf.NextProtos = []string{protoToReturn}
+		return tlsConf, nil
 	}
-
-	tlsConf.NextProtos = []string{protoToReturn}
-	return tlsConf, nil
 }

--- a/protocol/tls.go
+++ b/protocol/tls.go
@@ -21,7 +21,8 @@ import (
 // configuration will be chained to.
 //
 // Supported options: WithWrapper (passed through to LoadRootCertificate),
-// WithRandReader (passed through to ServerConfig and GenerateServerCertificates)
+// WithRandReader (passed through to ServerConfig and
+// GenerateServerCertificates)
 func (l *InterceptingListener) getTlsConfigForClient(clientInfo *ClientInfo) func(*tls.ClientHelloInfo) (*tls.Config, error) {
 	const op = "nodeenrollment.protocol.(InterceptingListener).getTlsConfigForClient"
 

--- a/tls/client.go
+++ b/tls/client.go
@@ -136,5 +136,6 @@ func ClientConfig(ctx context.Context, n *types.NodeCredentials, opt ...nodeenro
 	if err != nil {
 		return nil, fmt.Errorf("(%s) error breaking request into next protos: %w", op, err)
 	}
+	tlsConfig.NextProtos = append(tlsConfig.NextProtos, opts.WithExtraAlpnProtos...)
 	return tlsConfig, nil
 }

--- a/tls/client.go
+++ b/tls/client.go
@@ -18,7 +18,7 @@ import (
 // NodeCredentials. The values populated here can be used or modified as needed.
 //
 // Supported options: WithRandomReader, WithServerName (passed through to
-// standardTlsConfig)
+// standardTlsConfig), WithExtraAlpnProtos
 func ClientConfig(ctx context.Context, n *types.NodeCredentials, opt ...nodeenrollment.Option) (*tls.Config, error) {
 	const op = "nodeenrollment.tls.ClientConfig"
 

--- a/tls/client_test.go
+++ b/tls/client_test.go
@@ -82,7 +82,7 @@ func TestClientConfig(t *testing.T) {
 				n, wantErrContains = tt.setupFn(proto.Clone(n).(*types.NodeCredentials))
 			}
 
-			resp, err := ClientConfig(ctx, n, nodeenrollment.WithServerName("foobar"))
+			resp, err := ClientConfig(ctx, n, nodeenrollment.WithServerName("foobar"), nodeenrollment.WithExtraAlpnProtos([]string{"foo", "bar"}))
 			switch wantErrContains {
 			case "":
 				require.NoError(err)
@@ -102,6 +102,8 @@ func TestClientConfig(t *testing.T) {
 			// validating certs, boo. We simply validate that the generated cert
 			// validates against the returned roots.
 			assert.Equal("foobar", resp.ServerName)
+			assert.Contains(resp.NextProtos, "foo")
+			assert.Contains(resp.NextProtos, "bar")
 			assert.Len(resp.Certificates, 2)
 			for _, tlsCert := range resp.Certificates {
 				assert.Len(tlsCert.Certificate, 2)


### PR DESCRIPTION
These will be available server-side via casting the returned conn to a
*protocol.Conn. We can add more information into that struct if we need
to in the future.