### PR TITLE
Fix TLS handshake when certs have not rotated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,122 @@
+# Folders
+_obj
+_test
+.cover
+
+# IntelliJ IDEA project files
+.idea
+*.ipr
+*.iml
+*.iws
+
+### Logs ###
+*.log
+logs/
+
+### direnv ###
+.envrc
+.direnv/
+
+### Temp directories ###
+tmp/
+temp/
+
+### Visual Studio ###
+.vscode/
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+### Git ###
+# Created by git for backups. To disable backups in Git:
+# $ git config --global mergetool.keepBackup false
+*.orig
+
+# Created by git when using merge tools for conflicts
+*.BACKUP.*
+*.BASE.*
+*.LOCAL.*
+*.REMOTE.*
+*_BACKUP_*.txt
+*_BASE_*.txt
+*_LOCAL_*.txt
+*_REMOTE_*.txt
+
+### Go ###
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+### Tags ###
+# Ignore tags created by etags, ctags, gtags (GNU global) and cscope
+TAGS
+.TAGS
+!TAGS/
+tags
+.tags
+!tags/
+gtags.files
+GTAGS
+GRTAGS
+GPATH
+GSYMS
+cscope.files
+cscope.out
+cscope.in.out
+cscope.po.out
+
+### Vagrant ###
+# General
+.vagrant/
+
+# Log files (if you are creating logs in debug mode, uncomment this)
+# *.log
+
+### Vagrant Patch ###
+*.box
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+*~
+
+# Auto-generated tag files
+# Persistent undo
+[._]*.un~
+
+# Compilation outputs
+main
+/pkg/
+/bin/
+
+.schema-diff/

--- a/options.go
+++ b/options.go
@@ -46,6 +46,7 @@ type Options struct {
 	WithActivationToken                         string
 	WithMaximumServerLedActivationTokenLifetime time.Duration
 	WithNativeConns                             bool
+	WithTestErrorContains                       string
 }
 
 // Option is a function that takes in an options struct and sets values or
@@ -221,6 +222,14 @@ func WithMaximumServerLedActivationTokenLifetime(with time.Duration) Option {
 func WithNativeConns(with bool) Option {
 	return func(o *Options) error {
 		o.WithNativeConns = with
+		return nil
+	}
+}
+
+// WithTestErrorContains is used in some tests to pass expected error values
+func WithTestErrorContains(with string) Option {
+	return func(o *Options) error {
+		o.WithTestErrorContains = with
 		return nil
 	}
 }

--- a/options_test.go
+++ b/options_test.go
@@ -183,4 +183,13 @@ func Test_GetOpts(t *testing.T) {
 		require.NoError(err)
 		assert.True(opts.WithNativeConns)
 	})
+	t.Run("with-test-error-contains", func(t *testing.T) {
+		assert, require := assert.New(t), require.New(t)
+		opts, err := GetOpts()
+		require.NoError(err)
+		assert.Empty(opts.WithTestErrorContains)
+		opts, err = GetOpts(WithTestErrorContains("foobar"))
+		require.NoError(err)
+		assert.Equal("foobar", opts.WithTestErrorContains)
+	})
 }

--- a/rotation/roots.go
+++ b/rotation/roots.go
@@ -29,7 +29,9 @@ import (
 //
 // Supported options: WithRandomReader, WithCertificateLifetime, WithWrapper
 // (passed through to LoadRootCertificates and RootCertificates.Store),
-// WithSkipStorage, WithNotBeforeClockSkew, WithReinitializeRoots
+// WithSkipStorage, WithNotBeforeClockSkew, WithNotAfterClockSkew, WithReinitializeRoots
+//
+// Note that WithNotAfterClockSkew is cumulative with WithCertificatLifetime
 func RotateRootCertificates(ctx context.Context, storage nodeenrollment.Storage, opt ...nodeenrollment.Option) (*types.RootCertificates, error) {
 	const op = "nodeenrollment.rotation.RotateRootCertificates"
 	opts, err := nodeenrollment.GetOpts(opt...)
@@ -107,7 +109,7 @@ func RotateRootCertificates(ctx context.Context, storage nodeenrollment.Storage,
 				KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageKeyAgreement | x509.KeyUsageCertSign,
 				SerialNumber:          big.NewInt(mathrand.Int63()),
 				NotBefore:             now.Add(opts.WithNotBeforeClockSkew),
-				NotAfter:              now.Add(opts.WithCertificateLifetime),
+				NotAfter:              now.Add(opts.WithCertificateLifetime).Add(opts.WithNotAfterClockSkew),
 				BasicConstraintsValid: true,
 				IsCA:                  true,
 			}

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -14,7 +14,7 @@ import (
 
 // CommonTestParams is a one-stop shop returning a context, valid storage with
 // root certificates, and pre-registered node credentials for testing
-func CommonTestParams(t *testing.T) (context.Context, nodeenrollment.Storage, *types.NodeCredentials) {
+func CommonTestParams(t *testing.T, opt ...nodeenrollment.Option) (context.Context, nodeenrollment.Storage, *types.NodeCredentials) {
 	t.Helper()
 	ctx := context.Background()
 
@@ -22,7 +22,7 @@ func CommonTestParams(t *testing.T) (context.Context, nodeenrollment.Storage, *t
 	require.NoError(t, err)
 	t.Cleanup(storage.Cleanup)
 
-	_, err = rotation.RotateRootCertificates(ctx, storage)
+	_, err = rotation.RotateRootCertificates(ctx, storage, opt...)
 	require.NoError(t, err)
 
 	_, activationToken, err := registration.CreateServerLedActivationToken(ctx, storage, &types.ServerLedRegistrationRequest{})

--- a/tls/client.go
+++ b/tls/client.go
@@ -104,13 +104,13 @@ func ClientConfig(ctx context.Context, n *types.NodeCredentials, opt ...nodeenro
 	var tlsCerts []tls.Certificate
 
 	var foundCert bool
+	now := time.Now()
+	var leafX509 *x509.Certificate
 	for _, certBundle := range n.CertificateBundles {
 		if foundCert {
 			break
 		}
 
-		var leafX509 *x509.Certificate
-		now := time.Now()
 		// Parse node certificate
 		{
 			var err error

--- a/tls/client.go
+++ b/tls/client.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/nodeenrollment"
 	"github.com/hashicorp/nodeenrollment/types"
@@ -102,8 +103,14 @@ func ClientConfig(ctx context.Context, n *types.NodeCredentials, opt ...nodeenro
 	rootPool := x509.NewCertPool()
 	var tlsCerts []tls.Certificate
 
+	var foundCert bool
 	for _, certBundle := range n.CertificateBundles {
+		if foundCert {
+			break
+		}
+
 		var leafX509 *x509.Certificate
+		now := time.Now()
 		// Parse node certificate
 		{
 			var err error
@@ -111,9 +118,16 @@ func ClientConfig(ctx context.Context, n *types.NodeCredentials, opt ...nodeenro
 			if err != nil {
 				return nil, fmt.Errorf("(%s) error parsing node certificate bytes: %w", op, err)
 			}
-
 			if leafX509 == nil {
 				return nil, fmt.Errorf("(%s) after parsing node cert found empty value", op)
+			}
+			// It's expired
+			if leafX509.NotAfter.Before(now) {
+				continue
+			}
+			// It's not yet valid
+			if leafX509.NotBefore.After(now) {
+				continue
 			}
 		}
 
@@ -126,7 +140,14 @@ func ClientConfig(ctx context.Context, n *types.NodeCredentials, opt ...nodeenro
 			if serverCert == nil {
 				return nil, fmt.Errorf("(%s) after parsing server cert found empty value", op)
 			}
-			// log.Println(op, "adding client CA serial", serverCert.SerialNumber.String())
+			// It's expired
+			if serverCert.NotAfter.Before(now) {
+				continue
+			}
+			// It's not yet valid
+			if serverCert.NotBefore.After(now) {
+				continue
+			}
 			rootPool.AddCert(serverCert)
 		}
 
@@ -138,6 +159,12 @@ func ClientConfig(ctx context.Context, n *types.NodeCredentials, opt ...nodeenro
 			PrivateKey: signer,
 			Leaf:       leafX509,
 		})
+
+		foundCert = true
+	}
+
+	if len(tlsCerts) == 0 {
+		return nil, fmt.Errorf("(%s) no valid client certificates found", op)
 	}
 
 	// Require nonce in DNS names in verification function

--- a/tls/server.go
+++ b/tls/server.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math/big"
 	mathrand "math/rand"
+	"time"
 
 	"github.com/hashicorp/nodeenrollment"
 	"github.com/hashicorp/nodeenrollment/types"
@@ -193,15 +194,37 @@ func ServerConfig(
 	var tlsCerts []tls.Certificate
 	rootPool := x509.NewCertPool()
 
+	var foundCert bool
+	now := time.Now()
 	for _, certBundle := range in.CertificateBundles {
+		if foundCert {
+			break
+		}
+
 		leafCert, err := x509.ParseCertificate(certBundle.CertificateDer)
 		if err != nil {
 			return nil, fmt.Errorf("(%s) error parsing leaf certificate: %w", op, err)
+		}
+		// It's expired
+		if leafCert.NotAfter.Before(now) {
+			continue
+		}
+		// It's not yet valid
+		if leafCert.NotBefore.After(now) {
+			continue
 		}
 
 		serverCert, err := x509.ParseCertificate(certBundle.CaCertificateDer)
 		if err != nil {
 			return nil, fmt.Errorf("(%s) error parsing server certificate: %w", op, err)
+		}
+		// It's expired
+		if serverCert.NotAfter.Before(now) {
+			continue
+		}
+		// It's not yet valid
+		if serverCert.NotBefore.After(now) {
+			continue
 		}
 
 		rootPool.AddCert(serverCert)
@@ -214,6 +237,12 @@ func ServerConfig(
 			PrivateKey: privKey,
 			Leaf:       leafCert,
 		})
+
+		foundCert = true
+	}
+
+	if len(tlsCerts) == 0 {
+		return nil, fmt.Errorf("(%s) no valid server certificates found", op)
 	}
 
 	tlsConf, err := standardTlsConfig(ctx, tlsCerts, rootPool, opt...)

--- a/tls/standard_test.go
+++ b/tls/standard_test.go
@@ -117,6 +117,16 @@ func TestStandardTls(t *testing.T) {
 			},
 		),
 	)
+
+	// This tests that we are not sending expired certs for the handshake
+	t.Log("expired-cert")
+	ctx, storage, node = nodetesting.CommonTestParams(t,
+		nodeenrollment.WithCertificateLifetime(10*time.Second),
+		nodeenrollment.WithNotBeforeClockSkew(0),
+		nodeenrollment.WithNotAfterClockSkew(0),
+	)
+	time.Sleep(10 * time.Second)
+	runTest(t, ctx, storage, node, false)
 }
 
 func runTest(t *testing.T, ctx context.Context, storage nodeenrollment.Storage, nodeCreds *types.NodeCredentials, shouldFailHandshake bool, opt ...nodeenrollment.Option) {
@@ -209,7 +219,11 @@ func runTest(t *testing.T, ctx context.Context, storage nodeenrollment.Storage, 
 	// Dial on the client side and also check for errors (expected or not)
 	tlsConn, err := tls.Dial("tcp4", dialAddr, clientTlsConfig)
 	if shouldFailHandshake {
-		assert.Error(err)
+		if opts.WithTestErrorContains != "" {
+			assert.ErrorContains(err, opts.WithTestErrorContains)
+		} else {
+			assert.Error(err)
+		}
 		cancel()
 		return
 	}


### PR DESCRIPTION
All existing certificates were being given to tls configuration even though only one was being used. If the one that was being used was expired due to rotation not happening (or not happening yet), this would mean a failure to handshake.