### PR TITLE
Perform certificate lookup

### DIFF
--- a/common.go
+++ b/common.go
@@ -29,7 +29,8 @@ func ContainsKnownAlpnProto(protos ...string) bool {
 	for _, p := range protos {
 		switch {
 		case strings.HasPrefix(p, FetchNodeCredsNextProtoV1Prefix),
-			strings.HasPrefix(p, AuthenticateNodeNextProtoV1Prefix):
+			strings.HasPrefix(p, AuthenticateNodeNextProtoV1Prefix),
+			strings.HasPrefix(p, CertificatePreferenceV1Prefix):
 			return true
 		}
 	}

--- a/const.go
+++ b/const.go
@@ -50,6 +50,10 @@ const (
 	// is trying to authenticate
 	AuthenticateNodeNextProtoV1Prefix = "v1-nodee-authenticate-node-"
 
+	// CertificatePreferenceV1Prefix is the ALPN NextProto used by a node to
+	// indicate a certificate preference, since we can't use ServerName
+	CertificatePreferenceV1Prefix = "v1-nodee-certificate-preference-"
+
 	// NonceSize is our defined nonce size, in bytes
 	NonceSize = 32
 

--- a/options.go
+++ b/options.go
@@ -162,7 +162,7 @@ func WithAlpnProtoPrefix(with string) Option {
 	const op = "nodeenrollment.WithAlpnProtoPrefix"
 	return func(o *Options) error {
 		switch with {
-		case FetchNodeCredsNextProtoV1Prefix, AuthenticateNodeNextProtoV1Prefix:
+		case FetchNodeCredsNextProtoV1Prefix, AuthenticateNodeNextProtoV1Prefix, CertificatePreferenceV1Prefix:
 			o.WithAlpnProtoPrefix = with
 			return nil
 		default:

--- a/protocol/dialer.go
+++ b/protocol/dialer.go
@@ -184,12 +184,6 @@ func attemptFetch(ctx context.Context, nonTlsConn net.Conn, creds *types.NodeCre
 		return nil, fmt.Errorf("(%s) error splitting request into next protos: %w", op, err)
 	}
 
-	// Add the common dns name certificate selector. We don't have anything
-	// better to use here because we don't have certs, and on the other side
-	// this is an indicator that it's a fetch request.
-	// splitNextProtos = append(splitNextProtos,
-	//	fmt.Sprintf("%s%s", nodeenrollment.CertificatePreferenceV1Prefix, nodeenrollment.CommonDnsName))
-
 	// We need to use TLS for the connection but we aren't relying on its
 	// security. Create a self-signed cert and embed our info into it.
 	template := &x509.Certificate{

--- a/protocol/dialer.go
+++ b/protocol/dialer.go
@@ -61,6 +61,7 @@ func Dial(
 		return nonTlsConn, nil
 	}
 
+	// Fetch credentials for the node
 	creds, err := types.LoadNodeCredentials(ctx, storage, nodeenrollment.CurrentId, opt...)
 	if err != nil && !errors.Is(err, nodeenrollment.ErrNotFound) {
 		return nil, fmt.Errorf("(%s) unable to load node credentials: %w", op, err)
@@ -69,7 +70,8 @@ func Dial(
 		return nil, fmt.Errorf("(%s) loaded node credentials are nil", op)
 	}
 
-	// Add in the address to SNI, but first ensure we're only adding the host
+	// Add in the address to SNI for LB routing, but first ensure we're only
+	// adding the host
 	host, _, err := net.SplitHostPort(addr)
 	if err != nil {
 		if strings.Contains(err.Error(), "missing port") {
@@ -81,7 +83,7 @@ func Dial(
 	opt = append(opt, nodeenrollment.WithServerName(host))
 
 	if len(creds.CertificateBundles) == 0 {
-		// We haven't fetched creds yet, so attempt it
+		// We don't have creds yet, so attempt fetching them
 		nonTlsConn, err := nonTlsConnFn()
 		if err != nil {
 			return nil, fmt.Errorf("(%s) unable to dial to server: %w", op, err)
@@ -106,26 +108,38 @@ func Dial(
 		// creds, and can proceed connecting
 	}
 
-	nonTlsConn, err := nonTlsConnFn()
-	if err != nil {
-		return nil, fmt.Errorf("(%s) unable to dial to server: %w", op, err)
-	}
-
-	tlsConfig, err := nodetls.ClientConfig(ctx, creds, opt...)
+	tlsConfigs, err := nodetls.ClientConfigs(ctx, creds, opt...)
 	if err != nil {
 		return nil, fmt.Errorf("(%s) unable to get tls config from node creds: %w", op, err)
 	}
-	tlsConn := tls.Client(nonTlsConn, tlsConfig)
-
-	if err := tlsConn.HandshakeContext(ctx); err != nil {
-		return nil, fmt.Errorf("(%s) error handshaking tls connection: %w", op, err)
+	if len(tlsConfigs) == 0 {
+		return nil, fmt.Errorf("(%s) no valid tls client configs could be generated", op)
 	}
 
-	return tlsConn, nil
+	// We have two configs: one will ask for a chain with the current CA cert,
+	// and one with the next one (at least from the perspective of this client).
+	// We could return one along with the IDs to use and have this code embed
+	// one or the other but that seems more of a hassle than just ranging
+	// through this and trying to connect.
+	var tlsErrors *multierror.Error
+	for _, tlsConfig := range tlsConfigs {
+		nonTlsConn, err := nonTlsConnFn()
+		if err != nil {
+			return nil, fmt.Errorf("(%s) unable to dial to server: %w", op, err)
+		}
+		tlsConn := tls.Client(nonTlsConn, tlsConfig)
+		if err := tlsConn.HandshakeContext(ctx); err != nil {
+			tlsErrors = multierror.Append(tlsErrors, fmt.Errorf("(%s) error handshaking tls connection: %w", op, err))
+			continue
+		}
+		return tlsConn, nil
+	}
+
+	return nil, fmt.Errorf("(%s) errors encountered attempting to create client TLS connection: %w", op, tlsErrors)
 }
 
 // attemptFetch creates a signed fetch request and tries to perform a TLS
-// handshake, reading the resulting certificate
+// handshake, reading the resulting response
 //
 // If not authorized, returns nodeenrollment.ErrNotAuthorized
 func attemptFetch(ctx context.Context, nonTlsConn net.Conn, creds *types.NodeCredentials, opt ...nodeenrollment.Option) (*types.FetchNodeCredentialsResponse, error) {
@@ -170,6 +184,12 @@ func attemptFetch(ctx context.Context, nonTlsConn net.Conn, creds *types.NodeCre
 		return nil, fmt.Errorf("(%s) error splitting request into next protos: %w", op, err)
 	}
 
+	// Add the common dns name certificate selector. We don't have anything
+	// better to use here because we don't have certs, and on the other side
+	// this is an indicator that it's a fetch request.
+	// splitNextProtos = append(splitNextProtos,
+	//	fmt.Sprintf("%s%s", nodeenrollment.CertificatePreferenceV1Prefix, nodeenrollment.CommonDnsName))
+
 	// We need to use TLS for the connection but we aren't relying on its
 	// security. Create a self-signed cert and embed our info into it.
 	template := &x509.Certificate{
@@ -202,7 +222,7 @@ func attemptFetch(ctx context.Context, nonTlsConn net.Conn, creds *types.NodeCre
 	tlsConf := &tls.Config{
 		Rand: opts.WithRandomReader,
 		GetClientCertificate: func(
-			cri *tls.CertificateRequestInfo,
+			_ *tls.CertificateRequestInfo,
 		) (*tls.Certificate, error) {
 			return tlsCert, nil
 		},
@@ -224,9 +244,11 @@ func attemptFetch(ctx context.Context, nonTlsConn net.Conn, creds *types.NodeCre
 	switch commonName {
 	case nodeenrollment.CommonDnsName:
 		// We're unauthorized
+		// log.Println("got common name")
 		return nil, nodeenrollment.ErrNotAuthorized
 
 	default:
+		// log.Println("common name was", commonName)
 		respBytes, err := base64.RawStdEncoding.DecodeString(tlsConn.ConnectionState().PeerCertificates[0].Subject.CommonName)
 		if err != nil {
 			return nil, fmt.Errorf("(%s) error base64 decoding fetch response: %w", op, err)

--- a/protocol/tls.go
+++ b/protocol/tls.go
@@ -27,14 +27,25 @@ func (l *InterceptingListener) getTlsConfigForClient(clientInfo *ClientInfo) fun
 	const op = "nodeenrollment.protocol.(InterceptingListener).getTlsConfigForClient"
 
 	return func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
+		var trimmedProtos []string
 		// Copy client next proto information to returned value
 		if len(hello.SupportedProtos) > 0 {
-			clientInfo.nextProtos = make([]string, len(hello.SupportedProtos))
-			copy(clientInfo.nextProtos, hello.SupportedProtos)
+			trimmedProtos = make([]string, len(hello.SupportedProtos))
+			// If we have a certificate selector in NextProtos, pull it out and remove it from the list
+			// of protos, as it's only for internal routing use
+			for _, proto := range hello.SupportedProtos {
+				if strings.HasPrefix(proto, nodeenrollment.CertificatePreferenceV1Prefix) {
+					continue
+				}
+				trimmedProtos = append(trimmedProtos, proto)
+			}
+			clientInfo.nextProtos = trimmedProtos
 		}
 
+		// log.Println("incoming server name", hello.ServerName)
+
 		// If they aren't announcing support, return the base configuration
-		if !nodeenrollment.ContainsKnownAlpnProto(hello.SupportedProtos...) {
+		if !nodeenrollment.ContainsKnownAlpnProto(trimmedProtos...) {
 			if l.baseTlsConf == nil {
 				return nil, fmt.Errorf("(%s) no base tls configuration and no library next proto", op)
 			}
@@ -48,7 +59,7 @@ func (l *InterceptingListener) getTlsConfigForClient(clientInfo *ClientInfo) fun
 		var protoToReturn string
 		opt := l.options
 
-		for _, p := range hello.SupportedProtos {
+		for _, p := range trimmedProtos {
 			switch {
 			// In either scenario, we will present a carefully curated server
 			// certificate with information the node can use. How that certificate
@@ -71,8 +82,10 @@ func (l *InterceptingListener) getTlsConfigForClient(clientInfo *ClientInfo) fun
 				}
 				// This will return a response either with Authorized false and no
 				// other data or Authorized true and encrypted values
+				// log.Println("fetching creds")
 				fetchResp, err := l.fetchCredsFn(l.ctx, l.storage, req, l.options...)
 				if err != nil {
+					// log.Println("error fetching creds", err)
 					return nil, fmt.Errorf("(%s) error handling fetch creds: %w", op, err)
 				}
 
@@ -84,21 +97,30 @@ func (l *InterceptingListener) getTlsConfigForClient(clientInfo *ClientInfo) fun
 				}
 
 				switch {
-				case fetchResp == nil:
-					// In this case we're not authorized, use the standard common
-					// name and we'll detect this on the fetch side. If we try to
-					// marshal the empty value we end up with a zero length message,
-					// a zero-length base-64 message, and hit an error later if we
-					// don't remember this when decoding. So just use a canary.
+				case fetchResp == nil || fetchResp.EncryptedNodeCredentials == nil:
+					// In this case we're not authorized, use the standard
+					// common name and we'll detect this on the fetch side. If
+					// we try to marshal a nil value value we end up with a zero
+					// length message, a zero-length base-64 message, and hit an
+					// error later if we don't remember this when decoding. So
+					// create an empty message as a canary.
+					// log.Println("fetchResp was nil")
+					fetchResp = new(types.FetchNodeCredentialsResponse)
 					serverCertsReq.CommonName = nodeenrollment.CommonDnsName
+					// Ensure that our server TLS will serve the cert with the common name
+					opt = append(opt, nodeenrollment.WithServerName(nodeenrollment.CommonDnsName))
 
 				default:
+					// log.Println("fetchResp was not nil")
 					fetchRespBytes, err := proto.Marshal(fetchResp)
 					if err != nil {
 						return nil, fmt.Errorf("(%s) error marshaling fetch response: %w", op, err)
 					}
 					// Have the response put into the common name
 					serverCertsReq.CommonName = base64.RawStdEncoding.EncodeToString(fetchRespBytes)
+					// log.Println("common name just after marshaling", serverCertsReq.CommonName)
+					// Ensure that our server TLS will serve the cert with the common name
+					opt = append(opt, nodeenrollment.WithServerName(nodeenrollment.CommonDnsName))
 				}
 
 				// We are returning either unauthorized or encrypted creds so we
@@ -138,6 +160,7 @@ func (l *InterceptingListener) getTlsConfigForClient(clientInfo *ClientInfo) fun
 		}
 
 		// Generate a server-side certificate
+		// log.Println("before fn, common name in req", serverCertsReq.CommonName)
 		certResp, err := l.generateServerCertificatesFn(l.ctx, l.storage, serverCertsReq, opt...)
 		if err != nil {
 			return nil, fmt.Errorf("(%s) error generating server-side certificate: %w", op, err)

--- a/registration/register_node_led.go
+++ b/registration/register_node_led.go
@@ -207,7 +207,9 @@ func FetchNodeCredentials(
 	}
 
 	if nodeInfo == nil {
-		// Unauthorized, so return empty
+		// Unauthorized, so return empty. We cannot return nil because this will
+		// cause a marshal error if this function is via RPC since gRPC does not
+		// allow nil responses.
 		return new(types.FetchNodeCredentialsResponse), nil
 	}
 
@@ -364,12 +366,17 @@ func authorizeNodeCommon(
 				Subject: pkix.Name{
 					CommonName: nodeInfo.Id,
 				},
-				DNSNames:     []string{nodeenrollment.CommonDnsName},
+				DNSNames:     []string{nodeInfo.Id},
 				KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageKeyAgreement,
 				SerialNumber: big.NewInt(mathrand.Int63()),
 				NotBefore:    caCert.NotBefore,
 				NotAfter:     caCert.NotAfter,
 			}
+
+			// TODO: After enough time, remove this; it's here because
+			// verification code used to expect it, but these days we want to
+			// only use it in the context of fetching
+			template.DNSNames = append(template.DNSNames, nodeenrollment.CommonDnsName)
 
 			certificateDer, err := x509.CreateCertificate(opts.WithRandomReader, template, caCert, ed25519.PublicKey(certPubKey), caPrivKey)
 			if err != nil {

--- a/rotation/roots.go
+++ b/rotation/roots.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"errors"
 	"fmt"
 	"math/big"
@@ -79,6 +80,7 @@ func RotateRootCertificates(ctx context.Context, storage nodeenrollment.Storage,
 			newRoot = new(types.RootCertificate)
 			pubKey  ed25519.PublicKey
 			privKey ed25519.PrivateKey
+			keyId   string
 		)
 		// Create certificate key
 		{
@@ -93,7 +95,7 @@ func RotateRootCertificates(ctx context.Context, storage nodeenrollment.Storage,
 			}
 			newRoot.PrivateKeyType = types.KEYTYPE_ED25519
 
-			newRoot.PublicKeyPkix, _, err = nodeenrollment.SubjectKeyInfoAndKeyIdFromPubKey(pubKey)
+			newRoot.PublicKeyPkix, keyId, err = nodeenrollment.SubjectKeyInfoAndKeyIdFromPubKey(pubKey)
 			if err != nil {
 				return nil, fmt.Errorf("(%s) error fetching public key id: %w", op, err)
 			}
@@ -103,9 +105,12 @@ func RotateRootCertificates(ctx context.Context, storage nodeenrollment.Storage,
 		{
 			now := time.Now()
 			template := &x509.Certificate{
-				AuthorityKeyId:        newRoot.PublicKeyPkix,
-				SubjectKeyId:          newRoot.PublicKeyPkix,
-				DNSNames:              []string{nodeenrollment.CommonDnsName},
+				AuthorityKeyId: newRoot.PublicKeyPkix,
+				SubjectKeyId:   newRoot.PublicKeyPkix,
+				Subject: pkix.Name{
+					CommonName: keyId,
+				},
+				DNSNames:              []string{keyId},
 				KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageKeyAgreement | x509.KeyUsageCertSign,
 				SerialNumber:          big.NewInt(mathrand.Int63()),
 				NotBefore:             now.Add(opts.WithNotBeforeClockSkew),
@@ -113,6 +118,11 @@ func RotateRootCertificates(ctx context.Context, storage nodeenrollment.Storage,
 				BasicConstraintsValid: true,
 				IsCA:                  true,
 			}
+
+			// TODO: After enough time, remove this; it's here because
+			// verification code used to expect it, but these days we want to
+			// only use it in the context of fetching
+			template.DNSNames = append(template.DNSNames, nodeenrollment.CommonDnsName)
 
 			if kind == nodeenrollment.NextId {
 				newRoot.Id = string(nodeenrollment.NextId)

--- a/rotation/roots_test.go
+++ b/rotation/roots_test.go
@@ -2,6 +2,7 @@ package rotation
 
 import (
 	"context"
+	"crypto/x509"
 	"testing"
 	"time"
 
@@ -62,6 +63,13 @@ func TestRotateRootCertificates(t *testing.T) {
 		} else {
 			next = root
 		}
+		keyId, err := nodeenrollment.KeyIdFromPkix(root.PublicKeyPkix)
+		require.NoError(err)
+		cert, err := x509.ParseCertificate(root.CertificateDer)
+		require.NoError(err)
+		assert.Contains(cert.DNSNames, nodeenrollment.CommonDnsName)
+		assert.Contains(cert.DNSNames, keyId)
+		assert.Equal(cert.Subject.CommonName, keyId)
 	}
 
 	// Sleep until after the skew period or the logic might think something was

--- a/tls/client.go
+++ b/tls/client.go
@@ -24,7 +24,7 @@ import (
 // Supported options: WithRandomReader, WithServerName (passed through to
 // standardTlsConfig), WithExtraAlpnProtos, WithState
 func ClientConfigs(ctx context.Context, n *types.NodeCredentials, opt ...nodeenrollment.Option) ([]*tls.Config, error) {
-	const op = "nodeenrollment.tls.ClientConfig"
+	const op = "nodeenrollment.tls.ClientConfigs"
 
 	switch {
 	case n == nil:

--- a/tls/client.go
+++ b/tls/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/ed25519"
+	"crypto/subtle"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
@@ -15,12 +16,14 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// ClientConfig creates a client-side tls.Config by from the given
+// ClientConfigs creates client-side tls.Config by from the given
 // NodeCredentials. The values populated here can be used or modified as needed.
+// There are two to represent using current and next as tje certificate selector
+// passed via ALPN, so dials can be attempted with either.
 //
 // Supported options: WithRandomReader, WithServerName (passed through to
 // standardTlsConfig), WithExtraAlpnProtos, WithState
-func ClientConfig(ctx context.Context, n *types.NodeCredentials, opt ...nodeenrollment.Option) (*tls.Config, error) {
+func ClientConfigs(ctx context.Context, n *types.NodeCredentials, opt ...nodeenrollment.Option) ([]*tls.Config, error) {
 	const op = "nodeenrollment.tls.ClientConfig"
 
 	switch {
@@ -101,84 +104,116 @@ func ClientConfig(ctx context.Context, n *types.NodeCredentials, opt ...nodeenro
 	reqStr := base64.RawStdEncoding.EncodeToString(reqBytes)
 
 	rootPool := x509.NewCertPool()
-	var tlsCerts []tls.Certificate
 
-	var foundCert bool
-	now := time.Now()
-	var leafX509 *x509.Certificate
-	for _, certBundle := range n.CertificateBundles {
-		if foundCert {
-			break
-		}
-
-		// Parse node certificate
-		{
-			var err error
-			leafX509, err = x509.ParseCertificate(certBundle.CertificateDer)
-			if err != nil {
-				return nil, fmt.Errorf("(%s) error parsing node certificate bytes: %w", op, err)
-			}
-			if leafX509 == nil {
-				return nil, fmt.Errorf("(%s) after parsing node cert found empty value", op)
-			}
-			// It's expired
-			if leafX509.NotAfter.Before(now) {
-				continue
-			}
-			// It's not yet valid
-			if leafX509.NotBefore.After(now) {
-				continue
-			}
-		}
-
-		// Parse CA certificate
-		{
-			serverCert, err := x509.ParseCertificate(certBundle.CaCertificateDer)
-			if err != nil {
-				return nil, fmt.Errorf("(%s) error parsing server certificate bytes: %w", op, err)
-			}
-			if serverCert == nil {
-				return nil, fmt.Errorf("(%s) after parsing server cert found empty value", op)
-			}
-			// It's expired
-			if serverCert.NotAfter.Before(now) {
-				continue
-			}
-			// It's not yet valid
-			if serverCert.NotBefore.After(now) {
-				continue
-			}
-			rootPool.AddCert(serverCert)
-		}
-
-		tlsCerts = append(tlsCerts, tls.Certificate{
-			Certificate: [][]byte{
-				certBundle.CertificateDer,
-				certBundle.CaCertificateDer,
-			},
-			PrivateKey: signer,
-			Leaf:       leafX509,
-		})
-
-		foundCert = true
+	type certBundle struct {
+		leaf *x509.Certificate
+		ca   *x509.Certificate
 	}
+	certMap := map[string]*certBundle{}
 
-	if len(tlsCerts) == 0 {
-		return nil, fmt.Errorf("(%s) no valid client certificates found", op)
+	now := time.Now()
+	for _, bundle := range n.CertificateBundles {
+		//
+		// Parse node certificate
+		//
+		var err error
+		leafCert, err := x509.ParseCertificate(bundle.CertificateDer)
+		if err != nil {
+			return nil, fmt.Errorf("(%s) error parsing node certificate bytes: %w", op, err)
+		}
+		if leafCert == nil {
+			return nil, fmt.Errorf("(%s) after parsing node cert found empty value", op)
+		}
+		// It's expired
+		if leafCert.NotAfter.Before(now) {
+			continue
+		}
+		// It's not yet valid
+		if leafCert.NotBefore.After(now) {
+			continue
+		}
+
+		//
+		// Parse CA certificate
+		//
+		caCert, err := x509.ParseCertificate(bundle.CaCertificateDer)
+		if err != nil {
+			return nil, fmt.Errorf("(%s) error parsing ca certificate bytes: %w", op, err)
+		}
+		if caCert == nil {
+			return nil, fmt.Errorf("(%s) after parsing ca cert found empty value", op)
+		}
+		// It's expired
+		if caCert.NotAfter.Before(now) {
+			continue
+		}
+		// It's not yet valid
+		if caCert.NotBefore.After(now) {
+			continue
+		}
+		rootPool.AddCert(caCert)
+
+		caCertKkixPubKey, err := x509.MarshalPKIXPublicKey(caCert.PublicKey)
+		if err != nil {
+			return nil, fmt.Errorf("(%s) error marshaling ca cert pub key: %w", op, err)
+		}
+		caCertKeyId, err := nodeenrollment.KeyIdFromPkix(caCertKkixPubKey)
+		if err != nil {
+			return nil, fmt.Errorf("(%s) error deriving key id from ca cert pub key: %w", op, err)
+		}
+
+		certMap[caCertKeyId] = &certBundle{
+			leaf: leafCert,
+			ca:   caCert,
+		}
+		// log.Println("client side adding", keyId, "to certMap")
 	}
 
 	// Require nonce in DNS names in verification function
 	opt = append(opt, nodeenrollment.WithNonce(base64.RawStdEncoding.EncodeToString(nonceBytes)))
 
-	tlsConfig, err := standardTlsConfig(ctx, tlsCerts, rootPool, opt...)
-	if err != nil {
-		return nil, fmt.Errorf("(%s) error fetching standard tls config: %w", op, err)
+	// Get a config for each valid client cert, identified using SNI to pick the
+	// chain on the other end
+	var tlsConfigs []*tls.Config
+	for caCertKeyId := range certMap {
+		tlsConfig, err := standardTlsConfig(ctx, rootPool, opt...)
+		if err != nil {
+			return nil, fmt.Errorf("(%s) error fetching standard tls config: %w", op, err)
+		}
+
+		tlsConfig.NextProtos, err = BreakIntoNextProtos(nodeenrollment.AuthenticateNodeNextProtoV1Prefix, reqStr)
+		if err != nil {
+			return nil, fmt.Errorf("(%s) error breaking request into next protos: %w", op, err)
+		}
+		tlsConfig.NextProtos = append(tlsConfig.NextProtos, opts.WithExtraAlpnProtos...)
+		// Add the certificate selector
+		tlsConfig.NextProtos = append(tlsConfig.NextProtos,
+			fmt.Sprintf("%s%s", nodeenrollment.CertificatePreferenceV1Prefix, caCertKeyId))
+
+		// This function will look at the incoming CAs, identified by their
+		// subject key, and look for a known cert chain we have that is from
+		// that key
+		tlsConfig.GetClientCertificate = func(cri *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			for _, acceptableCa := range cri.AcceptableCAs {
+				// log.Println("GetClientCertificate", base64.RawStdEncoding.EncodeToString(acceptableCa))
+				for _, bundle := range certMap {
+					if subtle.ConstantTimeCompare(bundle.ca.RawSubject, acceptableCa) == 1 {
+						return &tls.Certificate{
+							Certificate: [][]byte{
+								bundle.leaf.Raw,
+								bundle.ca.Raw,
+							},
+							PrivateKey: signer,
+							Leaf:       bundle.leaf,
+						}, nil
+					}
+				}
+			}
+			return nil, fmt.Errorf("(%s) did not find a certificate acceptable to server roots", op)
+		}
+
+		tlsConfigs = append(tlsConfigs, tlsConfig)
 	}
 
-	tlsConfig.NextProtos, err = BreakIntoNextProtos(nodeenrollment.AuthenticateNodeNextProtoV1Prefix, reqStr)
-	if err != nil {
-		return nil, fmt.Errorf("(%s) error breaking request into next protos: %w", op, err)
-	}
-	tlsConfig.NextProtos = append(tlsConfig.NextProtos, opts.WithExtraAlpnProtos...)
-	return tlsConfig, nil
+	return tlsConfigs, nil
 }

--- a/tls/client.go
+++ b/tls/client.go
@@ -18,7 +18,7 @@ import (
 
 // ClientConfigs creates client-side tls.Config by from the given
 // NodeCredentials. The values populated here can be used or modified as needed.
-// There are two to represent using current and next as tje certificate selector
+// There are two to represent using current and next as the certificate selector
 // passed via ALPN, so dials can be attempted with either.
 //
 // Supported options: WithRandomReader, WithServerName (passed through to

--- a/tls/client_test.go
+++ b/tls/client_test.go
@@ -2,6 +2,7 @@ package tls
 
 import (
 	"crypto/ed25519"
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
 	"testing"
@@ -16,7 +17,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func TestClientConfig(t *testing.T) {
+func TestClientConfigs(t *testing.T) {
 	t.Parallel()
 
 	ctx, _, nodeCreds := nodetesting.CommonTestParams(t)
@@ -83,16 +84,20 @@ func TestClientConfig(t *testing.T) {
 				n, wantErrContains = tt.setupFn(proto.Clone(n).(*types.NodeCredentials))
 			}
 
-			resp, err := ClientConfig(ctx, n, nodeenrollment.WithServerName("foobar"), nodeenrollment.WithExtraAlpnProtos([]string{"foo", "bar"}), nodeenrollment.WithState(tt.state))
+			tlsConfigs, err := ClientConfigs(ctx, n, nodeenrollment.WithServerName("foobar"), nodeenrollment.WithExtraAlpnProtos([]string{"foo", "bar"}), nodeenrollment.WithState(tt.state))
 			switch wantErrContains {
 			case "":
 				require.NoError(err)
-				require.NotNil(resp)
+				// We'll only have one because the second won't be valid yet
+				require.Len(tlsConfigs, 1)
 			default:
 				require.Error(err)
 				assert.Contains(err.Error(), wantErrContains)
 				return
 			}
+
+			// Pull out the key identifier
+			tlsConfig := tlsConfigs[0]
 
 			// Check out the TLS parameters. Note that this doesn't re-check
 			// parameters already tested via the tests on standardTlsConfig.
@@ -102,30 +107,33 @@ func TestClientConfig(t *testing.T) {
 			// them or iterate over them so we have to just try manually
 			// validating certs, boo. We simply validate that the generated cert
 			// validates against the returned roots.
-			assert.Equal("foobar", resp.ServerName)
-			assert.Contains(resp.NextProtos, "foo")
-			assert.Contains(resp.NextProtos, "bar")
-			assert.Len(resp.Certificates, 2)
-			for _, tlsCert := range resp.Certificates {
-				assert.Len(tlsCert.Certificate, 2)
-				assert.Equal(tlsCert.Certificate[0], tlsCert.Leaf.Raw)
-				assert.NotEmpty(tlsCert.PrivateKey)
-				assert.NotEmpty(tlsCert.Certificate[1])
+			assert.Equal("foobar", tlsConfig.ServerName)
+			assert.Contains(tlsConfig.NextProtos, "foo")
+			assert.Contains(tlsConfig.NextProtos, "bar")
 
-				verifyOpts := x509.VerifyOptions{
-					Roots:     resp.RootCAs,
-					KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
-				}
+			expCaCert, err := x509.ParseCertificate(n.CertificateBundles[0].CaCertificateDer)
+			require.NoError(err)
+			tlsCert, err := tlsConfig.GetClientCertificate(&tls.CertificateRequestInfo{
+				AcceptableCAs: [][]byte{expCaCert.RawSubject},
+			})
+			require.NoError(err)
+			require.NotNil(tlsCert)
+			assert.NotEmpty(tlsCert.PrivateKey)
+			assert.NotEmpty(tlsCert.Certificate[1])
 
-				if tlsCert.Leaf.NotBefore.Before(time.Now()) && tlsCert.Leaf.NotAfter.After(time.Now()) {
-					chains, err := tlsCert.Leaf.Verify(verifyOpts)
-					require.NoError(err)
-					assert.Less(0, len(chains))
-				}
+			verifyOpts := x509.VerifyOptions{
+				Roots:     tlsConfig.RootCAs,
+				KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+			}
+
+			if tlsCert.Leaf.NotBefore.Before(time.Now()) && tlsCert.Leaf.NotAfter.After(time.Now()) {
+				chains, err := tlsCert.Leaf.Verify(verifyOpts)
+				require.NoError(err)
+				assert.Less(0, len(chains))
 			}
 
 			// Break up NextProtos and check the request
-			reqStr, err := CombineFromNextProtos(nodeenrollment.AuthenticateNodeNextProtoV1Prefix, resp.NextProtos)
+			reqStr, err := CombineFromNextProtos(nodeenrollment.AuthenticateNodeNextProtoV1Prefix, tlsConfig.NextProtos)
 			require.NoError(err)
 			reqBytes, err := base64.RawStdEncoding.DecodeString(reqStr)
 			require.NoError(err)

--- a/tls/server.go
+++ b/tls/server.go
@@ -173,7 +173,7 @@ func GenerateServerCertificates(
 // ServerConfig takes in a generate response and turns it into a server-side TLS
 // configuration
 //
-// Supported options: WithServerName, which causes use that as the value in the
+// Supported options: WithServerName, which will be the value used in the
 // cert map for lookup; also, options passed in here will be passed through to
 // the standard TLS configuration function (useful for tests, mainly)
 func ServerConfig(

--- a/tls/server.go
+++ b/tls/server.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math/big"
 	mathrand "math/rand"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/nodeenrollment"
@@ -124,6 +125,11 @@ func GenerateServerCertificates(
 			return nil, fmt.Errorf("(%s) error getting signing params: %w", op, err)
 		}
 
+		keyId, err := nodeenrollment.KeyIdFromPkix(rootCert.PublicKeyPkix)
+		if err != nil {
+			return nil, fmt.Errorf("(%s) error deriving key id for root cert: %w", op, err)
+		}
+
 		template := &x509.Certificate{
 			AuthorityKeyId: serverCert.SubjectKeyId,
 			SubjectKeyId:   req.CertificatePublicKeyPkix,
@@ -131,9 +137,9 @@ func GenerateServerCertificates(
 				x509.ExtKeyUsageServerAuth,
 			},
 			Subject: pkix.Name{
-				CommonName: nodeenrollment.CommonDnsName,
+				CommonName: keyId,
 			},
-			DNSNames:     []string{nodeenrollment.CommonDnsName},
+			DNSNames:     []string{keyId},
 			KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageKeyAgreement,
 			SerialNumber: big.NewInt(mathrand.Int63()),
 			NotBefore:    serverCert.NotBefore,
@@ -142,8 +148,10 @@ func GenerateServerCertificates(
 		if len(req.Nonce) > 0 {
 			template.DNSNames = append(template.DNSNames, base64.RawStdEncoding.EncodeToString(req.Nonce))
 		}
+		// log.Println("req common name", req.CommonName)
 		if req.CommonName != "" {
 			template.Subject.CommonName = req.CommonName
+			template.DNSNames = append(template.DNSNames, req.CommonName)
 		}
 
 		leafCert, err := x509.CreateCertificate(opts.WithRandomReader, template, serverCert, pubKey, signer)
@@ -165,9 +173,9 @@ func GenerateServerCertificates(
 // ServerConfig takes in a generate response and turns it into a server-side TLS
 // configuration
 //
-// Supported options: none, although options passed in here will be passed
-// through to the standard TLS configuration function (useful for tests,
-// mainly)
+// Supported options: WithServerName, which causes use that as the value in the
+// cert map for lookup; also, options passed in here will be passed through to
+// the standard TLS configuration function (useful for tests, mainly)
 func ServerConfig(
 	ctx context.Context,
 	in *types.GenerateServerCertificatesResponse,
@@ -186,22 +194,31 @@ func ServerConfig(
 		return nil, fmt.Errorf("(%s) invalid input certificate bundles, wanted 2 bundles, got %d", op, len(in.CertificateBundles))
 	}
 
+	opts, err := nodeenrollment.GetOpts(opt...)
+	if err != nil {
+		return nil, fmt.Errorf("(%s) error parsing options: %w", op, err)
+	}
+
 	privKey, err := x509.ParsePKCS8PrivateKey(in.CertificatePrivateKeyPkcs8)
 	if err != nil {
 		return nil, fmt.Errorf("(%s) error parsing private key: %w", op, err)
 	}
 
-	var tlsCerts []tls.Certificate
 	rootPool := x509.NewCertPool()
 
-	var foundCert bool
-	now := time.Now()
-	for _, certBundle := range in.CertificateBundles {
-		if foundCert {
-			break
-		}
+	type certBundle struct {
+		leaf *x509.Certificate
+		ca   *x509.Certificate
+	}
+	certMap := map[string]*certBundle{}
 
-		leafCert, err := x509.ParseCertificate(certBundle.CertificateDer)
+	now := time.Now()
+
+	for _, bundle := range in.CertificateBundles {
+		//
+		// Parse server certificate
+		//
+		leafCert, err := x509.ParseCertificate(bundle.CertificateDer)
 		if err != nil {
 			return nil, fmt.Errorf("(%s) error parsing leaf certificate: %w", op, err)
 		}
@@ -214,40 +231,91 @@ func ServerConfig(
 			continue
 		}
 
-		serverCert, err := x509.ParseCertificate(certBundle.CaCertificateDer)
+		//
+		// Parse CA certificate
+		//
+		caCert, err := x509.ParseCertificate(bundle.CaCertificateDer)
 		if err != nil {
-			return nil, fmt.Errorf("(%s) error parsing server certificate: %w", op, err)
+			return nil, fmt.Errorf("(%s) error parsing ca certificate: %w", op, err)
 		}
 		// It's expired
-		if serverCert.NotAfter.Before(now) {
+		if caCert.NotAfter.Before(now) {
 			continue
 		}
 		// It's not yet valid
-		if serverCert.NotBefore.After(now) {
+		if caCert.NotBefore.After(now) {
 			continue
 		}
+		rootPool.AddCert(caCert)
 
-		rootPool.AddCert(serverCert)
+		caCertPkixPubKey, err := x509.MarshalPKIXPublicKey(caCert.PublicKey)
+		if err != nil {
+			return nil, fmt.Errorf("(%s) error marshaling ca cert pub key: %w", op, err)
+		}
+		caCertKeyId, err := nodeenrollment.KeyIdFromPkix(caCertPkixPubKey)
+		if err != nil {
+			return nil, fmt.Errorf("(%s) error deriving key id from ca cert pub key: %w", op, err)
+		}
 
-		tlsCerts = append(tlsCerts, tls.Certificate{
-			Certificate: [][]byte{
-				leafCert.Raw,
-				serverCert.Raw,
-			},
-			PrivateKey: privKey,
-			Leaf:       leafCert,
-		})
+		certMap[caCertKeyId] = &certBundle{
+			leaf: leafCert,
+			ca:   caCert,
+		}
 
-		foundCert = true
+		// log.Println("server side adding", caCertKeyId, "to certMap")
+
+		// If a server name is given, add it to the map. One of the ways this is
+		// used is during fetching, where we don't have a key ID; we pass in the
+		// standard name here, and the fetch attempt on the other side will use
+		// it during the handshake.
+		if opts.WithServerName != "" && certMap[opts.WithServerName] == nil {
+			// log.Println("server side adding", opts.WithServerName, "to certMap via opts.WithServerName")
+			certMap[opts.WithServerName] = &certBundle{
+				leaf: leafCert,
+				ca:   caCert,
+			}
+		}
 	}
 
-	if len(tlsCerts) == 0 {
-		return nil, fmt.Errorf("(%s) no valid server certificates found", op)
-	}
-
-	tlsConf, err := standardTlsConfig(ctx, tlsCerts, rootPool, opt...)
+	tlsConf, err := standardTlsConfig(ctx, rootPool, opt...)
 	if err != nil {
 		return nil, fmt.Errorf("(%s) error generating standard tls config: %w", op, err)
+	}
+
+	tlsConf.GetCertificate = func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+		var certificateSelector string
+		for _, proto := range hello.SupportedProtos {
+			if strings.HasPrefix(proto, nodeenrollment.CertificatePreferenceV1Prefix) {
+				certificateSelector = strings.TrimPrefix(proto, nodeenrollment.CertificatePreferenceV1Prefix)
+				break
+			}
+		}
+		// If we don't find a certificate selector it's an older client. If a
+		// server name was provided, use that; if not just pick something and
+		// hope for the best, which is basically the old logic anyways...
+		// log.Println("GetCertificate", certificateSelector)
+		if certificateSelector == "" {
+			certificateSelector = opts.WithServerName
+		}
+		if certificateSelector == "" {
+			for k := range certMap {
+				certificateSelector = k
+				break
+			}
+		}
+		bundle := certMap[certificateSelector]
+		if bundle == nil {
+			// log.Println("GetCertificate, selector not found", certificateSelector)
+			return nil, nil
+		}
+		return &tls.Certificate{
+			Certificate: [][]byte{
+				bundle.leaf.Raw,
+				bundle.ca.Raw,
+			},
+			PrivateKey: privKey,
+			Leaf:       bundle.leaf,
+		}, nil
 	}
 
 	return tlsConf, nil

--- a/tls/standard.go
+++ b/tls/standard.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509"
 	"fmt"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nodeenrollment"
 )
 
@@ -20,12 +19,10 @@ import (
 //
 // Supported options: WithRandomReader, WithNonce, WithVerifyConnectionFunc,
 // WithExpectedPublicKey, WithServerName
-func standardTlsConfig(ctx context.Context, tlsCerts []tls.Certificate, pool *x509.CertPool, opt ...nodeenrollment.Option) (*tls.Config, error) {
+func standardTlsConfig(ctx context.Context, pool *x509.CertPool, opt ...nodeenrollment.Option) (*tls.Config, error) {
 	const op = "nodeenrollment.tls.standardTlsConfig"
 
 	switch {
-	case len(tlsCerts) == 0:
-		return nil, fmt.Errorf("(%s) no tls certificates provided", op)
 	case pool == nil:
 		return nil, fmt.Errorf("(%s) nil ca pool provided", op)
 	}
@@ -36,8 +33,7 @@ func standardTlsConfig(ctx context.Context, tlsCerts []tls.Certificate, pool *x5
 	}
 
 	verifyOpts := x509.VerifyOptions{
-		DNSName: nodeenrollment.CommonDnsName,
-		Roots:   pool,
+		Roots: pool,
 		KeyUsages: []x509.ExtKeyUsage{
 			x509.ExtKeyUsageClientAuth,
 			x509.ExtKeyUsageServerAuth,
@@ -49,12 +45,11 @@ func standardTlsConfig(ctx context.Context, tlsCerts []tls.Certificate, pool *x5
 	if opts.WithTlsVerifyOptionsFunc != nil {
 		verifyOpts = opts.WithTlsVerifyOptionsFunc(pool)
 	}
-
+	// log.Println("creating tls config with server name", opts.WithServerName)
 	tlsConfig := &tls.Config{
 		Rand:               opts.WithRandomReader,
 		ClientAuth:         tls.RequireAnyClientCert,
 		MinVersion:         tls.VersionTLS13,
-		Certificates:       tlsCerts,
 		RootCAs:            pool,
 		ClientCAs:          pool,
 		InsecureSkipVerify: true,
@@ -69,21 +64,14 @@ func standardTlsConfig(ctx context.Context, tlsCerts []tls.Certificate, pool *x5
 				// value.
 				return nil
 			}
-			var retErr *multierror.Error
-			for _, cert := range cs.PeerCertificates {
-				if _, err := cert.Verify(verifyOpts); err != nil {
-					retErr = multierror.Append(retErr, err)
-					continue
-				}
-				if len(opts.WithExpectedPublicKey) != 0 {
-					if subtle.ConstantTimeCompare(opts.WithExpectedPublicKey, cert.SubjectKeyId) != 1 {
-						retErr = multierror.Append(retErr, fmt.Errorf("(%s) subject key ID does not match", op))
-						continue
-					}
-				}
-				return nil
+			leaf := cs.PeerCertificates[0]
+			if _, err := leaf.Verify(verifyOpts); err != nil {
+				return fmt.Errorf("(%s) error verifying peer certificate: %w", op, err)
 			}
-			return fmt.Errorf("(%s) errors verifying certificates: %w", op, retErr)
+			if len(opts.WithExpectedPublicKey) != 0 && subtle.ConstantTimeCompare(opts.WithExpectedPublicKey, leaf.SubjectKeyId) != 1 {
+				return fmt.Errorf("(%s) subject key ID does not match: %w", op, err)
+			}
+			return nil
 		},
 	}
 

--- a/tls/standard_test.go
+++ b/tls/standard_test.go
@@ -136,9 +136,10 @@ func runTest(t *testing.T, ctx context.Context, storage nodeenrollment.Storage, 
 	require.NoError(err)
 
 	// Get our client config
-	clientTlsConfig, err := ClientConfig(ctx, nodeCreds, opt...)
+	clientTlsConfigs, err := ClientConfigs(ctx, nodeCreds, opt...)
 	require.NoError(err)
-	require.NotNil(clientTlsConfig)
+	require.Len(clientTlsConfigs, 1)
+	clientTlsConfig := clientTlsConfigs[0]
 
 	if opts.WithServerName != "" {
 		assert.Equal("barfoo", clientTlsConfig.ServerName)


### PR DESCRIPTION
This allows us to definitively know what cert to present during TLS establishment.

Note for reviewers: I'm leaving these commented log.Println statements in because in `main` we have support for passing in a toggleable logger for debug and I want to migrate a lot of these to that logger, but it's too much of a change to pull in here (and for point releases of things using this lib).