### PR TITLE
Don't allow certificate lifetime to be set zero

### DIFF
--- a/options.go
+++ b/options.go
@@ -64,9 +64,15 @@ func getDefaultOptions() *Options {
 }
 
 // WithCertificateLifetime allows overriding a default duration for certificate
-// creation
+// creation. If 0 is passed in, the default will be used; to get an actual zero
+// lifetime (e.g. to only use skew), just specify something short, like a
+// nanosecond.
 func WithCertificateLifetime(with time.Duration) Option {
 	return func(o *Options) error {
+		if with == 0 {
+			o.WithCertificateLifetime = DefaultCertificateLifetime
+			return nil
+		}
 		o.WithCertificateLifetime = with
 		return nil
 	}

--- a/options_test.go
+++ b/options_test.go
@@ -28,6 +28,9 @@ func Test_GetOpts(t *testing.T) {
 		opts, err = GetOpts(WithCertificateLifetime(time.Hour))
 		require.NoError(err)
 		assert.Equal(time.Hour, opts.WithCertificateLifetime)
+		opts, err = GetOpts(WithCertificateLifetime(0))
+		require.NoError(err)
+		assert.Equal(DefaultCertificateLifetime, opts.WithCertificateLifetime)
 	})
 	t.Run("with-not-before-clock-skew", func(t *testing.T) {
 		assert, require := assert.New(t), require.New(t)


### PR DESCRIPTION
This is almost certainly not what a caller intended to do and instead is likely because the caller meant to simply use the default lifetime. So, specify zero as the default lifetime; if you truly want it short, setting it to literally anything other than zero will do what was desired.