### PR TITLE
Fix multilistener deadlock

### DIFF
--- a/net/splitlistener.go
+++ b/net/splitlistener.go
@@ -350,7 +350,7 @@ func (l *MultiplexingListener) IngressListener(ln net.Listener) error {
 	go func() {
 		for {
 			conn, err := ln.Accept()
-			if err != nil && errors.Is(err, net.ErrClosed) {
+			if err != nil {
 				return
 			}
 			l.closedMutex.RLock()

--- a/net/splitlistener.go
+++ b/net/splitlistener.go
@@ -277,11 +277,11 @@ func (l *MultiplexingListener) Addr() net.Addr {
 // We call drainConnections here to ensure that senders don't block even though
 // we're no longer accepting them.
 func (l *MultiplexingListener) Close() error {
+	l.drainConnections()
 	l.closedMutex.Lock()
 	l.closed = true
 	l.closedOnce.Do(func() { close(l.incoming) })
 	l.closedMutex.Unlock()
-	l.drainConnections()
 	return nil
 }
 


### PR DESCRIPTION
### [net: fix deadlock on close](https://github.com/hashicorp/nodeenrollment/pull/57/commits/ef1d1928f0e604f4a1412dd5abe17a7f91199376)

A deadlock could happen if listeners were ingressed without
any calls to Accept. We now drain the connections before taking
the lock on Close.

### [net: avoid nil pointer deference](https://github.com/hashicorp/nodeenrollment/pull/57/commits/2e665452aee49e078272be043f271e8b64c61137)

conn could be nil if a non-closed error was returned from the listener.