### PR TITLE
storage: pass options through on Load

### DIFF
--- a/options.go
+++ b/options.go
@@ -54,6 +54,7 @@ type Options struct {
 	WithNativeConns                                       bool
 	WithLogger                                            hclog.Logger
 	WithTestErrorContains                                 string
+	WithRemoveUnusedCredentials                           bool
 }
 
 // Option is a function that takes in an options struct and sets values or
@@ -272,6 +273,14 @@ func WithLogger(with hclog.Logger) Option {
 func WithTestErrorContains(with string) Option {
 	return func(o *Options) error {
 		o.WithTestErrorContains = with
+		return nil
+	}
+}
+
+// WithRemoveUnusedCredentials, if set to true, indicates that unused credentials should be removed
+func WithRemoveUnusedCredentials(with bool) Option {
+	return func(o *Options) error {
+		o.WithRemoveUnusedCredentials = with
 		return nil
 	}
 }

--- a/options_test.go
+++ b/options_test.go
@@ -233,4 +233,13 @@ func Test_GetOpts(t *testing.T) {
 		require.NoError(err)
 		assert.Equal("foobar", opts.WithTestErrorContains)
 	})
+	t.Run("with-remove-unused-creds", func(t *testing.T) {
+		assert, require := assert.New(t), require.New(t)
+		opts, err := GetOpts()
+		require.NoError(err)
+		assert.False(opts.WithRemoveUnusedCredentials)
+		opts, err = GetOpts(WithRemoveUnusedCredentials(true))
+		require.NoError(err)
+		assert.True(opts.WithRemoveUnusedCredentials)
+	})
 }

--- a/rotation/node.go
+++ b/rotation/node.go
@@ -60,8 +60,13 @@ func RotateNodeCredentials(
 		return nil, fmt.Errorf("(%s) %s", op, err.Error())
 	}
 
+	// Update options for rotation to remove unused credentials, if found
+	rotateOpts := make([]nodeenrollment.Option, len(opt))
+	copy(rotateOpts, opt)
+	rotateOpts = append(rotateOpts, nodeenrollment.WithRemoveUnusedCredentials(true))
+
 	// First we get our current node information and decrypt the fetch request
-	currentNodeInfo, err := types.LoadNodeInformation(ctx, storage, currentKeyId, opt...)
+	currentNodeInfo, err := types.LoadNodeInformation(ctx, storage, currentKeyId, rotateOpts...)
 	if err != nil {
 		err := fmt.Errorf("error loading current node information: %w", err)
 		opts.WithLogger.Error(err.Error(), "op", op)

--- a/storage.go
+++ b/storage.go
@@ -32,7 +32,7 @@ type Storage interface {
 	// Load loads values into the given message. The message must be populated
 	// with the ID of the value to load. If not found, the returned error should
 	// be ErrNotFound.
-	Load(context.Context, MessageWithId) error
+	Load(context.Context, MessageWithId, ...Option) error
 
 	// Remove removes the given message. The ID field of the message must be
 	// populated, and only the ID field of the message is considered.

--- a/storage/file/file.go
+++ b/storage/file/file.go
@@ -126,7 +126,7 @@ func (ts *Storage) Store(ctx context.Context, msg nodeenrollment.MessageWithId) 
 }
 
 // Load implements the Storage interface
-func (ts *Storage) Load(ctx context.Context, msg nodeenrollment.MessageWithId) error {
+func (ts *Storage) Load(ctx context.Context, msg nodeenrollment.MessageWithId, _ ...nodeenrollment.Option) error {
 	const op = "nodeenrollment.storage.file.(Storage).Load"
 	if err := types.ValidateMessage(msg); err != nil {
 		return fmt.Errorf("(%s) given message cannot be loaded: %w", op, err)

--- a/storage/inmem/inmem.go
+++ b/storage/inmem/inmem.go
@@ -77,7 +77,7 @@ func (ts *Storage) Store(ctx context.Context, msg nodeenrollment.MessageWithId) 
 }
 
 // Load implements the Storage interface
-func (ts *Storage) Load(ctx context.Context, msg nodeenrollment.MessageWithId) error {
+func (ts *Storage) Load(ctx context.Context, msg nodeenrollment.MessageWithId, _ ...nodeenrollment.Option) error {
 	const op = "nodeenrollment.storage.inmem.(Storage).Load"
 	if err := types.ValidateMessage(msg); err != nil {
 		return fmt.Errorf("(%s) given message cannot be loaded: %w", op, err)

--- a/types/node_information.go
+++ b/types/node_information.go
@@ -93,7 +93,7 @@ func LoadNodeInformation(ctx context.Context, storage nodeenrollment.Storage, id
 		Id:    id,
 		State: opts.WithState,
 	}
-	if err := storage.Load(ctx, nodeInfo); err != nil {
+	if err := storage.Load(ctx, nodeInfo, opt...); err != nil {
 		return nil, fmt.Errorf("(%s) error loading node information from storage: %w", op, err)
 	}
 


### PR DESCRIPTION
Add the ability to pass options on to Load implementations that support them.

For example, Boundary's DB implementation maintains a current and previous for NodeInformation. In a split brain scenario, rotation may occur with an abandoned "current" set of credentials that should be deleted when detected: https://github.com/hashicorp/boundary/pull/4822