### PR TITLE
Add PCI review checklist to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Description
+
+## PCI review checklist
+
+<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
+
+- [ ] I have documented a clear reason for, and description of, the change I am making.
+
+- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
+
+- [ ] If applicable, I've documented the impact of any changes to security controls.
+
+  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.


### PR DESCRIPTION
To support PCI (Payment Card Industry) certification, add PCI checklist to PR template.