### PR TITLE
feat(listener): Add client_addr to logs when timing out

### DIFF
--- a/protocol/listener.go
+++ b/protocol/listener.go
@@ -229,11 +229,16 @@ func (l *InterceptingListener) Accept() (conn net.Conn, retErr error) {
 			err := tlsConn.HandshakeContext(handshakeCtx)
 			c.setClientInfo(clientInfo.nextProtos, clientInfo.clientState)
 			if err != nil {
+				// Get remote address before closing
+				clientAddr := conn.RemoteAddr().String()
+
 				if closeErr := tlsConn.Close(); closeErr != nil {
 					err = errors.Join(err, fmt.Errorf("error closing connection: %w", closeErr))
 				}
 				err := fmt.Errorf("error tls handshaking server side: %w", err)
-				opts.WithLogger.Error(err.Error(), "op", op)
+				opts.WithLogger.Error(err.Error(),
+					"op", op,
+					"client_addr", clientAddr)
 				return temperror.New(fmt.Errorf("(%s) %s", op, err.Error()))
 			}
 

--- a/protocol/listener_test.go
+++ b/protocol/listener_test.go
@@ -4,6 +4,7 @@
 package protocol
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/tls"
@@ -13,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nodeenrollment"
 	nodetesting "github.com/hashicorp/nodeenrollment/testing"
 	nodetls "github.com/hashicorp/nodeenrollment/tls"
@@ -167,4 +169,119 @@ func TestInterceptingListener_CloseCancelsBlockedHandshake(t *testing.T) {
 
 	// All done lets cleanup
 	close(releaseClientCertificate)
+}
+
+func TestInterceptingListener_HandshakeTimeout(t *testing.T) {
+	t.Parallel()
+	require, assert := require.New(t), assert.New(t)
+
+	ctx, fileStorage, nodeCreds := nodetesting.CommonTestParams(t)
+
+	baseLn, err := net.Listen("tcp4", "127.0.0.1:0")
+	require.NoError(err)
+	t.Cleanup(func() {
+		_ = baseLn.Close()
+	})
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(err)
+	template := &x509.Certificate{
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageKeyAgreement | x509.KeyUsageCertSign,
+		SerialNumber:          big.NewInt(0),
+		NotBefore:             time.Now().Add(-30 * time.Second),
+		NotAfter:              time.Now().Add(5 * time.Minute),
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	certBytes, err := x509.CreateCertificate(rand.Reader, template, template, pub, priv)
+	require.NoError(err)
+	cert, err := x509.ParseCertificate(certBytes)
+	require.NoError(err)
+	certPool := x509.NewCertPool()
+	certPool.AddCert(cert)
+	baseTlsConf := &tls.Config{
+		Certificates: []tls.Certificate{{
+			Certificate: [][]byte{certBytes},
+			PrivateKey:  priv,
+			Leaf:        cert,
+		}},
+		RootCAs:            certPool,
+		InsecureSkipVerify: true,
+	}
+
+	// Pass our test logger to the listener so we can capture the logs for assertion later
+	logBuffer := new(bytes.Buffer)
+	logger := hclog.New(&hclog.LoggerOptions{
+		Name:   "test-listener",
+		Level:  hclog.Trace,
+		Output: logBuffer,
+	})
+
+	authingListener, err := NewInterceptingListener(&InterceptingListenerConfiguration{
+		Context:              ctx,
+		Storage:              fileStorage,
+		BaseListener:         baseLn,
+		BaseTlsConfiguration: baseTlsConf,
+		TlsHandshakeTimeout:  50 * time.Millisecond,
+		Options: []nodeenrollment.Option{
+			nodeenrollment.WithLogger(logger),
+		},
+	})
+	require.NoError(err)
+	t.Cleanup(func() {
+		_ = authingListener.Close()
+	})
+
+	serverHandshakeErr := make(chan error, 1)
+	go func() {
+		conn, err := authingListener.Accept()
+		require.NoError(err)
+
+		protoConn := conn.(*Conn)
+		serverHandshakeErr <- protoConn.Handshake()
+	}()
+
+	clientTlsConfigs, err := nodetls.ClientConfigs(ctx, nodeCreds)
+	require.NoError(err)
+	require.NotEmpty(clientTlsConfigs)
+
+	stalledClientTlsConf := clientTlsConfigs[0].Clone()
+	requestedClientCertificate := make(chan struct{}, 1)
+	releaseClientCertificate := make(chan struct{})
+	originalGetClientCertificate := stalledClientTlsConf.GetClientCertificate
+	stalledClientTlsConf.GetClientCertificate = func(cri *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+		select {
+		case requestedClientCertificate <- struct{}{}:
+		default:
+		}
+
+		<-releaseClientCertificate
+		return originalGetClientCertificate(cri)
+	}
+
+	stalledConn, err := net.Dial("tcp4", authingListener.Addr().String())
+	require.NoError(err)
+	defer stalledConn.Close()
+
+	go func() {
+		stalledTLSConn := tls.Client(stalledConn, stalledClientTlsConf)
+		defer stalledTLSConn.Close()
+		_ = stalledTLSConn.HandshakeContext(ctx)
+	}()
+
+	<-requestedClientCertificate
+
+	err = <-serverHandshakeErr
+	require.Error(err)
+
+	// Validate we got the context deadline exceeded error
+	assert.ErrorContains(err, "context deadline exceeded")
+
+	close(releaseClientCertificate)
+
+	// Validate we see the client_addr metadata in the timeout logs
+	assert.Contains(logBuffer.String(), "client_addr="+stalledConn.LocalAddr().String())
+	assert.Contains(logBuffer.String(), "error tls handshaking server side")
 }


### PR DESCRIPTION
## Description

Add client_addr to logs when timing out

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
