### PR TITLE
Update CreateServerLedActivationToken to return the token as well

### DIFF
--- a/registration/register_server_led.go
+++ b/registration/register_server_led.go
@@ -37,19 +37,19 @@ func CreateServerLedActivationToken(
 	storage nodeenrollment.Storage,
 	req *types.ServerLedRegistrationRequest,
 	opt ...nodeenrollment.Option,
-) (string, string, error) {
-	const op = "nodeenrollment.registration.RegisterViaServerLedFlow"
+) (*types.ServerLedActivationToken, string, error) {
+	const op = "nodeenrollment.registration.CreateServerLedActivationToken"
 
 	opts, err := nodeenrollment.GetOpts(opt...)
 	if err != nil {
-		return "", "", fmt.Errorf("(%s) error parsing options: %w", op, err)
+		return nil, "", fmt.Errorf("(%s) error parsing options: %w", op, err)
 	}
 
 	switch {
 	case req == nil:
-		return "", "", fmt.Errorf("(%s) nil request", op)
+		return nil, "", fmt.Errorf("(%s) nil request", op)
 	case !opts.WithSkipStorage && nodeenrollment.IsNil(storage):
-		return "", "", fmt.Errorf("(%s) nil storage", op)
+		return nil, "", fmt.Errorf("(%s) nil storage", op)
 	}
 
 	var (
@@ -63,9 +63,9 @@ func CreateServerLedActivationToken(
 		num, err := opts.WithRandomReader.Read(tokenNonce.Nonce)
 		switch {
 		case err != nil:
-			return "", "", fmt.Errorf("(%s) error generating nonce: %w", op, err)
+			return nil, "", fmt.Errorf("(%s) error generating nonce: %w", op, err)
 		case num != nodeenrollment.NonceSize:
-			return "", "", fmt.Errorf("(%s) read incorrect number of bytes for nonce, wanted %d, got %d", op, nodeenrollment.NonceSize, num)
+			return nil, "", fmt.Errorf("(%s) read incorrect number of bytes for nonce, wanted %d, got %d", op, nodeenrollment.NonceSize, num)
 		}
 		tokenEntry.RegistrationChallenge = &types.RegistrationChallenge{
 			Challenge: tokenNonce.Nonce,
@@ -78,9 +78,9 @@ func CreateServerLedActivationToken(
 		num, err := opts.WithRandomReader.Read(tokenNonce.HmacKeyBytes)
 		switch {
 		case err != nil:
-			return "", "", fmt.Errorf("(%s) error generating hmac key bytes: %w", op, err)
+			return nil, "", fmt.Errorf("(%s) error generating hmac key bytes: %w", op, err)
 		case num != 32:
-			return "", "", fmt.Errorf("(%s) read incorrect number of bytes for hmac key, wanted %d, got %d", op, nodeenrollment.NonceSize, num)
+			return nil, "", fmt.Errorf("(%s) read incorrect number of bytes for hmac key, wanted %d, got %d", op, nodeenrollment.NonceSize, num)
 		}
 		// Now, we're going to hmac the nonce; an encoding of the hmac value will
 		// give us the ID for storage of the activation token entry.
@@ -93,14 +93,14 @@ func CreateServerLedActivationToken(
 		num, err := opts.WithRandomReader.Read(tokenEntry.ServerEncryptionPrivateKeyBytes)
 		switch {
 		case err != nil:
-			return "", "", fmt.Errorf("(%s) error reading random bytes to generate node encryption key: %w", op, err)
+			return nil, "", fmt.Errorf("(%s) error reading random bytes to generate node encryption key: %w", op, err)
 		case num != curve25519.ScalarSize:
-			return "", "", fmt.Errorf("(%s) wrong number of random bytes read when generating node encryption key, expected %d but got %d", op, curve25519.ScalarSize, num)
+			return nil, "", fmt.Errorf("(%s) wrong number of random bytes read when generating node encryption key, expected %d but got %d", op, curve25519.ScalarSize, num)
 		}
 		tokenEntry.ServerEncryptionPrivateKeyType = types.KEYTYPE_X25519
 		encryptionPrivateKey, err := ecdh.X25519().NewPrivateKey(tokenEntry.ServerEncryptionPrivateKeyBytes)
 		if err != nil {
-			return "", "", fmt.Errorf("(%s) error reading node private encryption key: %w", op, err)
+			return nil, "", fmt.Errorf("(%s) error reading node private encryption key: %w", op, err)
 		}
 		tokenNonce.ServerEncryptionPublicKeyBytes = encryptionPrivateKey.PublicKey().Bytes()
 		tokenNonce.ServerEncryptionPublicKeyType = types.KEYTYPE_X25519
@@ -109,7 +109,7 @@ func CreateServerLedActivationToken(
 	// Now generate the returned value that will be transmitted by marshaling the token
 	returnedTokenBytes, err := proto.Marshal(tokenNonce)
 	if err != nil {
-		return "", "", fmt.Errorf("(%s) error marshaling token nonce: %w", op, err)
+		return nil, "", fmt.Errorf("(%s) error marshaling token nonce: %w", op, err)
 	}
 
 	tokenEntry.CreationTime = timestamppb.Now()
@@ -119,11 +119,11 @@ func CreateServerLedActivationToken(
 		// At this point everything is generated and both messages are prepared;
 		// store the value
 		if err := tokenEntry.Store(ctx, storage, opt...); err != nil {
-			return "", "", fmt.Errorf("(%s) error storing activation token: %w", op, err)
+			return nil, "", fmt.Errorf("(%s) error storing activation token: %w", op, err)
 		}
 	}
 
-	return tokenEntry.Id, fmt.Sprintf("%s%s", nodeenrollment.ServerLedActivationTokenPrefix, base58.FastBase58Encoding(returnedTokenBytes)), nil
+	return tokenEntry, fmt.Sprintf("%s%s", nodeenrollment.ServerLedActivationTokenPrefix, base58.FastBase58Encoding(returnedTokenBytes)), nil
 }
 
 func serverLedActivationTokenId(nonce, hmacKey []byte) string {

--- a/registration/register_server_led_test.go
+++ b/registration/register_server_led_test.go
@@ -48,7 +48,7 @@ func TestServerLedRegistration(t *testing.T) {
 
 	wrapper := aead.TestWrapper(t)
 
-	tokenId, token, err := registration.CreateServerLedActivationToken(ctx, storage, &types.ServerLedRegistrationRequest{}, nodeenrollment.WithStorageWrapper(wrapper))
+	te, token, err := registration.CreateServerLedActivationToken(ctx, storage, &types.ServerLedRegistrationRequest{}, nodeenrollment.WithStorageWrapper(wrapper))
 	require.NoError(err)
 	assert.NotEmpty(token)
 	assert.True(strings.HasPrefix(token, nodeenrollment.ServerLedActivationTokenPrefix))
@@ -63,7 +63,7 @@ func TestServerLedRegistration(t *testing.T) {
 	// New protocol: activation token ID and server encryption public key must
 	// be present in the nonce given to the node.
 	assert.NotEmpty(tokenNonce.ActivationTokenId)
-	assert.Equal(tokenId, tokenNonce.ActivationTokenId)
+	assert.Equal(te.Id, tokenNonce.ActivationTokenId)
 	assert.NotEmpty(tokenNonce.ServerEncryptionPublicKeyBytes)
 	assert.Equal(types.KEYTYPE_X25519, tokenNonce.ServerEncryptionPublicKeyType)
 	// Legacy fields must still be present for backwards compatibility.
@@ -73,12 +73,12 @@ func TestServerLedRegistration(t *testing.T) {
 	hm := hmac.New(sha256.New, tokenNonce.HmacKeyBytes)
 	hm.Write(tokenNonce.Nonce)
 	idBytes := hm.Sum(nil)
-	assert.Equal(tokenId, base58.FastBase58Encoding(idBytes))
-	decodedTokenId, err := base58.FastBase58Decoding(tokenId)
+	assert.Equal(te.Id, base58.FastBase58Encoding(idBytes))
+	decodedTokenId, err := base58.FastBase58Decoding(te.Id)
 	require.NoError(err)
 	assert.Len(decodedTokenId, sha256.Size)
 
-	tokenEntry, err := types.LoadServerLedActivationToken(ctx, storage, tokenId, nodeenrollment.WithStorageWrapper(wrapper))
+	tokenEntry, err := types.LoadServerLedActivationToken(ctx, storage, te.Id, nodeenrollment.WithStorageWrapper(wrapper))
 	require.NoError(err)
 	require.NotNil(tokenEntry)
 	assert.NotEmpty(tokenEntry.Id)
@@ -232,9 +232,9 @@ func TestServerLedRegistration_TokenIdOnlyRejected(t *testing.T) {
 	_, err = rotation.RotateRootCertificates(ctx, storage)
 	require.NoError(t, err)
 
-	tokenId, _, err := registration.CreateServerLedActivationToken(ctx, storage, &types.ServerLedRegistrationRequest{})
+	te, _, err := registration.CreateServerLedActivationToken(ctx, storage, &types.ServerLedRegistrationRequest{})
 	require.NoError(t, err)
-	require.NotEmpty(t, tokenId)
+	require.NotEmpty(t, te.Id)
 
 	nodeCreds, err := types.NewNodeCredentials(ctx, storage)
 	require.NoError(t, err)
@@ -242,7 +242,7 @@ func TestServerLedRegistration_TokenIdOnlyRejected(t *testing.T) {
 	require.NoError(t, err)
 
 	tokenNonce, err := proto.Marshal(&types.ServerLedActivationTokenNonce{
-		ActivationTokenId: tokenId,
+		ActivationTokenId: te.Id,
 	})
 	require.NoError(t, err)
 

--- a/types/node_credentials_test.go
+++ b/types/node_credentials_test.go
@@ -487,13 +487,13 @@ func TestNodeCredentials_CreateFetchNodeCredentialsServerLed(t *testing.T) {
 	mapOpt, err := structpb.NewStruct(applicationSpecificParamsMap)
 	require.NoError(t, err)
 
-	storageId, serverLedActivationToken, err := registration.CreateServerLedActivationToken(
+	te, serverLedActivationToken, err := registration.CreateServerLedActivationToken(
 		ctx,
 		storage,
 		&types.ServerLedRegistrationRequest{},
 	)
 	require.NoError(t, err)
-
+	storageId := te.Id
 	tests := []struct {
 		name string
 		// Return a modified node information and a "want err contains" string
@@ -588,6 +588,7 @@ func TestNodeCredentials_CreateFetchNodeCredentialsServerLed(t *testing.T) {
 			},
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require, assert := require.New(t), assert.New(t)


### PR DESCRIPTION
## Description

Backport to main branch of a fix for a problem introduced in the updates to the protocols, where the token information is not always available later.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [X] I have documented a clear reason for, and description of, the change I am making.

- [X] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [X] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
